### PR TITLE
ci(composer.json): add ci test script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "ci:lint": "composer exec \"@lint\"",
         "ci:lint-fix": "composer exec \"@lint-fix\"",
         "ci:test": "XDEBUG_MODE=coverage composer exec \"@test --configuration=phpunit.ci.xml --coverage-clover=build/logs/clover.xml\"",
+        "ci:test-build": "composer exec \"@test --configuration=phpunit.ci.xml\"",
         "ci:generate-coverage-badge": "composer exec \"php-coveralls -v\"",
         "lint": "phpcs",
         "lint-fix": "phpcbf",


### PR DESCRIPTION
The `PHP Composer` CI job was failing because the script did not exist.