### PR TITLE
fix: ignore phpdoc folder from dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@
 /.phan                      export-ignore
 /phpcs.xml                  export-ignore
 /phpdoc.xml                 export-ignore
+/.phpdoc                    export-ignore
 /phpunit.xml                export-ignore
 /phpunit.acceptance.xml     export-ignore
 /phpunit.ci.xml             export-ignore


### PR DESCRIPTION
The library should not include unnecessary artifacts.