### PR TITLE
test: use new code coverage attribute

### DIFF
--- a/tests/unit/ColumnNameTraitTest.php
+++ b/tests/unit/ColumnNameTraitTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Phpolar\Model;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(ColumnNameTrait::class)]
+#[CoversTrait(ColumnNameTrait::class)]
 #[CoversClass(Column::class)]
 final class ColumnNameTraitTest extends TestCase
 {

--- a/tests/unit/DataTypeTraitTest.php
+++ b/tests/unit/DataTypeTraitTest.php
@@ -10,11 +10,11 @@ use Stringable;
 use Phpolar\StorageDriver\DataTypeUnknown;
 use Phpolar\StorageDriver\StorageDriverInterface;
 use Phpolar\StorageDriver\TypeName;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(DataTypeDetectionTrait::class)]
+#[CoversTrait(DataTypeDetectionTrait::class)]
 final class DataTypeTraitTest extends TestCase
 {
     #[TestDox("Shall generate column parameter string from declared property type")]

--- a/tests/unit/EntityNameConfigurationTraitTest.php
+++ b/tests/unit/EntityNameConfigurationTraitTest.php
@@ -6,7 +6,7 @@ namespace Phpolar\Model;
 
 use Phpolar\Model\Tests\Stubs\EntityNameConfigured;
 use Phpolar\Model\Tests\Stubs\EntityNameNotConfigured;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -14,7 +14,7 @@ use ReflectionClass;
 use const Phpolar\Model\Tests\ENTITY_NAME_TEST_CASE;
 
 #[CoversClass(EntityName::class)]
-#[CoversClass(EntityNameConfigurationTrait::class)]
+#[CoversTrait(EntityNameConfigurationTrait::class)]
 final class EntityNameConfigurationTraitTest extends TestCase
 {
     #[TestDox("Shall return the configured entity name")]

--- a/tests/unit/FieldErrorMessageTraitTest.php
+++ b/tests/unit/FieldErrorMessageTraitTest.php
@@ -6,11 +6,11 @@ namespace Phpolar\Model;
 
 use Phpolar\Model\Tests\Stubs\InvalidPropertyStub;
 use Phpolar\Model\Tests\Stubs\ValidPropertyStub;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(FieldErrorMessageTrait::class)]
+#[CoversTrait(FieldErrorMessageTrait::class)]
 final class FieldErrorMessageTraitTest extends TestCase
 {
     #[TestDox("Shall produce expected error message when property validation fails")]

--- a/tests/unit/FormControlTypeDetectionTraitTest.php
+++ b/tests/unit/FormControlTypeDetectionTraitTest.php
@@ -8,11 +8,11 @@ use Closure;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(FormControlTypeDetectionTrait::class)]
+#[CoversTrait(FormControlTypeDetectionTrait::class)]
 final class FormControlTypeDetectionTraitTest extends TestCase
 {
     #[TestDox("Shall detect form control types")]

--- a/tests/unit/FormInputTypeDetectionTraitTest.php
+++ b/tests/unit/FormInputTypeDetectionTraitTest.php
@@ -8,11 +8,11 @@ use Closure;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(FormInputTypeDetectionTrait::class)]
+#[CoversTrait(FormInputTypeDetectionTrait::class)]
 final class FormInputTypeDetectionTraitTest extends TestCase
 {
     #[TestDox("Shall detect form input types")]

--- a/tests/unit/InputTypesTest.php
+++ b/tests/unit/InputTypesTest.php
@@ -6,12 +6,13 @@ namespace Phpolar\Model;
 
 use Phpolar\Phpolar\Core\Exception\InvalidInputTypeCastToStringException;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(InputTypes::class)]
-#[CoversClass(InvalidInputTypeCastToStringException::class)]
+#[CoversTrait(InvalidInputTypeCastToStringException::class)]
 final class InputTypesTest extends TestCase
 {
     public static function dataProvider(): array

--- a/tests/unit/LabelTest.php
+++ b/tests/unit/LabelTest.php
@@ -6,12 +6,13 @@ namespace Phpolar\Model;
 
 use Phpolar\Model\Tests\DataProviders\LabelDataProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Label::class)]
-#[CoversClass(LabelFormatTrait::class)]
+#[CoversTrait(LabelFormatTrait::class)]
 final class LabelTest extends TestCase
 {
     #[DataProviderExternal(LabelDataProvider::class, "getLabelTestCases")]

--- a/tests/unit/PrimaryKeyTraitTest.php
+++ b/tests/unit/PrimaryKeyTraitTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Phpolar\Model;
 
+
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(PrimaryKeyTrait::class)]
+#[CoversTrait(PrimaryKeyTrait::class)]
 #[CoversClass(PrimaryKey::class)]
 final class PrimaryKeyTraitTest extends TestCase
 {

--- a/tests/unit/SizeConfigurationTraitTest.php
+++ b/tests/unit/SizeConfigurationTraitTest.php
@@ -6,11 +6,12 @@ namespace Phpolar\Model;
 
 use Phpolar\Phpolar\Core\SizeNotConfigured;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Size::class)]
-#[CoversClass(SizeConfigurationTrait::class)]
+#[CoversTrait(SizeConfigurationTrait::class)]
 final class SizeConfigurationTraitTest extends TestCase
 {
     #[TestDox("Shall return the given argument as size")]


### PR DESCRIPTION
Using `CoversClass` for traits is deprecated.